### PR TITLE
Works with libc6 2.37

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
 all:
-	gcc -Wl,--no-as-needed -L/usr/lib/x86_64-linux-gnu/  -l:/usr/lib/x86_64-linux-gnu/libpython2.7.so -lpython2.7 -I/usr/include/python2.7 -pthread -shared -fPIC -o pyject.so pyject.c
+	gcc -Wl,--no-as-needed -L/usr/lib64/  -l:libpython3.11.so.1.0 -lpython3.11 -I/usr/include/python3.11 -pthread -shared -fPIC -o pyject.so pyject.c
 	gcc -pthread -shared -fPIC -o fancy.so fancy.c
+
+clean:
+	${RM} fancy.so pyject.so


### PR DESCRIPTION
I have updated inject_so.py to work with the current libc6, v2.37, as well as python 3.11.
It also gives you the error string if the ldopen should fail.
I did move some of the code into functions.

The fixes were needed, as:
- Injecting code at the rip then calling libc is risky, as the injected code may rewrite the function you are calling if rip is in libc.
- I found you needed your own stack when calling libc. Perhaps overwriting data on the stack is possible without this?
- ldd is merging into libc, so __libc_dlopen_mode is probably replaced by dlopen
- When finding the function offset in libc, you need to take into account the maps offset.
- various differences between python 2 and 3

It works for many executables. I did notice it struggled injecting into /bin/bash. My theory is that this uses signal handling with a signal action which confuses the stack and rip, and so with int3 is never reached. Perhaps signal masking would solve this, but it is fine for my experiments.